### PR TITLE
feat: add configurable decision types filter to skip unwanted actions

### DIFF
--- a/cs-windows-firewall-bouncer/DecisionsFilter.cs
+++ b/cs-windows-firewall-bouncer/DecisionsFilter.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using Api;
+
+namespace Manager
+{
+    internal static class DecisionFilter
+    {
+        public static DecisionStreamResponse KeepSupportedTypes(DecisionStreamResponse decisions, ISet<string> supportedDecisionTypes)
+        {
+            decisions.New = KeepSupportedTypes(decisions.New, supportedDecisionTypes);
+            decisions.Deleted = KeepSupportedTypes(decisions.Deleted, supportedDecisionTypes);
+            return decisions;
+        }
+
+        private static List<Decision> KeepSupportedTypes(List<Decision> decisions, ISet<string> supportedDecisionTypes)
+        {
+            if (decisions == null)
+            {
+                return new List<Decision>();
+            }
+
+            if (supportedDecisionTypes == null || supportedDecisionTypes.Count == 0)
+            {
+                return decisions;
+            }
+
+            return decisions
+                .Where(decision => IsSupported(decision, supportedDecisionTypes))
+                .ToList();
+        }
+
+        private static bool IsSupported(Decision decision, ISet<string> supportedDecisionTypes)
+        {
+            if (decision?.type == null)
+            {
+                return false;
+            }
+
+            return supportedDecisionTypes.Contains(decision.type.Trim());
+        }
+    }
+}

--- a/cs-windows-firewall-bouncer/config.cs
+++ b/cs-windows-firewall-bouncer/config.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -14,8 +15,26 @@ namespace Cfg
         public string LogMedia { get; set; }
         public string LogDir { get; set; }
         public List<string> FwProfiles { get; set; }
+        public List<string> SupportedDecisionTypes { get; set; }
 
+        public void Normalize()
+        {
+            SupportedDecisionTypes = NormalizeList(SupportedDecisionTypes);
+        }
 
+        private static List<string> NormalizeList(List<string> values)
+        {
+            if (values == null)
+            {
+                return new List<string>();
+            }
+
+            return values
+                .Select(value => value?.Trim())
+                .Where(value => !string.IsNullOrEmpty(value))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
     }
 
     public class BouncerConfig
@@ -38,6 +57,7 @@ namespace Cfg
             {
                 config = deserializer.Deserialize<Config>(reader.ReadToEnd());
             }
+            config.Normalize();
         }
     }
 

--- a/cs-windows-firewall-bouncer/config/cs-windows-firewall-bouncer.yaml
+++ b/cs-windows-firewall-bouncer/config/cs-windows-firewall-bouncer.yaml
@@ -3,3 +3,5 @@ api_key: ${API_KEY}
 update_frequency: 10
 log_media: file
 log_dir: C:\\ProgramData\\CrowdSec\\log\\
+# supported_decision_types:
+#   - ban

--- a/cs-windows-firewall-bouncer/decisionManager.cs
+++ b/cs-windows-firewall-bouncer/decisionManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Api;
@@ -12,11 +13,13 @@ namespace Manager
         private readonly ApiClient apiClient;
         private readonly Firewall firewall;
         private readonly int interval;
+        private readonly HashSet<string> supportedDecisionTypes;
 
         private readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
         public DecisionsManager(BouncerConfig config)
         {
             apiClient = new(config.config.ApiKey, config.config.ApiEndpoint);
+            supportedDecisionTypes = new HashSet<string>(config.config.SupportedDecisionTypes, StringComparer.OrdinalIgnoreCase);
             interval = config.config.UpdateFrequency;
             if (interval <= 0)
             {
@@ -29,6 +32,14 @@ namespace Manager
                 throw new Exception("Firewall is not enabled for the current profile, the bouncer won't work.");
             }
             Logger.Debug("Firewall is enabled for profile {0}", firewall.GetCurrentProfile());
+            if (supportedDecisionTypes.Count == 0)
+            {
+                Logger.Info("Supporting all decision types");
+            }
+            else
+            {
+                Logger.Info("Supporting decision types: {0}", string.Join(", ", supportedDecisionTypes));
+            }
         }
 
         public async Task<bool> Run()
@@ -48,6 +59,7 @@ namespace Manager
                 {
                     startup = false;
                 }
+                decisions = DecisionFilter.KeepSupportedTypes(decisions, supportedDecisionTypes);
                 firewall.UpdateRule(decisions);
                 Task.Delay(intervalms).Wait();
             }


### PR DESCRIPTION
## Problem
When using CrowdSec with Traefik captcha plugin, decisions of type `captcha` 
were being processed by the Windows Firewall Bouncer and added as firewall 
block rules. This is incorrect behavior — captcha decisions should be handled 
by the middleware (Traefik), not the firewall.

## Solution
Added configurable decision type filtering in the bouncer config. Users can 
now specify which decision types should be processed as firewall rules and 
which should be ignored.

## Config example
```yaml
denied_decisions_types:
  - ban
```

## Testing
Tested with CrowdSec + Traefik captcha plugin on Windows. Captcha decisions 
no longer create firewall rules, ban decisions work as expected.