### PR TITLE
Add Prometheus metrics

### DIFF
--- a/cs-windows-firewall-bouncer-setup/Product.wxs
+++ b/cs-windows-firewall-bouncer-setup/Product.wxs
@@ -29,7 +29,12 @@
       <ComponentRef Id="bouncerexe_service_start" />
       <ComponentRef Id="bouncerexe_service_dont_start" />
       <ComponentRef Id="bouncerconfig" />
-      <ComponentRef Id="fwbouncerother" />
+      <!-- Harvest every dependency from the bouncer build output (DLLs, runtimes\, .deps.json,
+           runtimeconfig.json). The .exe is excluded because it is installed by the service
+           components above; .pdb symbols are not shipped. -->
+      <Files Include="$(cs_windows_firewall_bouncer.TargetDir)\**"
+             Exclude="$(cs_windows_firewall_bouncer.TargetDir)\**\*.exe;$(cs_windows_firewall_bouncer.TargetDir)\**\*.pdb"
+             Directory="FirewallBouncerDir" />
     </Feature>
 
     <Property Id="CSCLIPRESENT">
@@ -120,17 +125,6 @@
                 
                 <ServiceInstall Id="BouncerService2" Name="cs-windows-firewall-bouncer" DisplayName="Crowdsec Windows Firewall Bouncer" Description="Crowdsec Windows Firewall Bouncer" Start="disabled" Type="ownProcess" ErrorControl="normal" Account="LocalSystem" Vital="no" Interactive="no" />
                 <ServiceControl Id="BouncerService2" Name="cs-windows-firewall-bouncer" Stop="both" Remove="uninstall" Wait="no" />
-              </Component>
-              <Component Id="fwbouncerother" Guid="4b650a10-7531-4569-ba49-0867ddadf482">
-                <File Id="nlog.dll" Source="$(cs_windows_firewall_bouncer.TargetDir)\NLog.dll" Name="NLog.dll" />
-                <File Id="fw.dll" Source="$(cs_windows_firewall_bouncer.TargetDir)\Interop.NetFwTypeLib.dll" Name="Interop.NetFwTypeLib.dll" />
-                <File Id="yaml.dll" Source="$(cs_windows_firewall_bouncer.TargetDir)\YamlDotNet.dll" Name="YamlDotNet.dll" />
-                <File Id="commandline.dll" Source="$(cs_windows_firewall_bouncer.TargetDir)\CommandLine.dll" Name="CommandLine.dll" />
-                <File Id="bouncer.dll" Source="$(cs_windows_firewall_bouncer.TargetDir)\cs-windows-firewall-bouncer.dll" Name="cs-windows-firewall-bouncer.dll" />
-                <File Id="service.dll" Source="$(cs_windows_firewall_bouncer.TargetDir)\runtimes\win\lib\net10.0\System.ServiceProcess.ServiceController.dll" Name="System.ServiceProcess.ServiceController.dll" />
-                <File Id="eventlog.dll" Source="$(cs_windows_firewall_bouncer.TargetDir)\runtimes\win\lib\net10.0\System.Diagnostics.EventLog.dll" Name="System.Diagnostics.EventLog.dll" />
-                <File Id="eventlog_message.dll" Source="$(cs_windows_firewall_bouncer.TargetDir)\runtimes\win\lib\net10.0\System.Diagnostics.EventLog.Messages.dll" Name="System.Diagnostics.EventLog.Messages.dll" />
-                <File Id="runtimeconfig.json" Source="$(cs_windows_firewall_bouncer.TargetDir)\cs-windows-firewall-bouncer.runtimeconfig.json" Name="cs-windows-firewall-bouncer.runtimeconfig.json" />
               </Component>
             </Directory>
           </Directory>

--- a/cs-windows-firewall-bouncer-setup/Product.wxs
+++ b/cs-windows-firewall-bouncer-setup/Product.wxs
@@ -32,10 +32,9 @@
       <!-- Harvest every dependency from the bouncer build output (DLLs, runtimes\, .deps.json,
            runtimeconfig.json). The .exe is excluded because it is installed by the service
            components above; .pdb symbols are not shipped. -->
-      <Files Directory="FirewallBouncerDir">
-        <Include Path="$(cs_windows_firewall_bouncer.TargetDir)\**" />
-        <Exclude Path="$(cs_windows_firewall_bouncer.TargetDir)\**\*.exe" />
-        <Exclude Path="$(cs_windows_firewall_bouncer.TargetDir)\**\*.pdb" />
+      <Files Directory="FirewallBouncerDir" Include="$(cs_windows_firewall_bouncer.TargetDir)\**">
+        <Exclude Files="$(cs_windows_firewall_bouncer.TargetDir)\**\*.exe" />
+        <Exclude Files="$(cs_windows_firewall_bouncer.TargetDir)\**\*.pdb" />
       </Files>
     </Feature>
 

--- a/cs-windows-firewall-bouncer-setup/Product.wxs
+++ b/cs-windows-firewall-bouncer-setup/Product.wxs
@@ -33,7 +33,7 @@
            runtimeconfig.json). The .exe is excluded because it is installed by the service
            components above; .pdb symbols are not shipped. -->
       <Files Include="$(cs_windows_firewall_bouncer.TargetDir)\**"
-             Exclude="$(cs_windows_firewall_bouncer.TargetDir)\**\*.exe;$(cs_windows_firewall_bouncer.TargetDir)\**\*.pdb"
+             Exclude="**\*.exe;**\*.pdb"
              Directory="FirewallBouncerDir" />
     </Feature>
 

--- a/cs-windows-firewall-bouncer-setup/Product.wxs
+++ b/cs-windows-firewall-bouncer-setup/Product.wxs
@@ -32,9 +32,11 @@
       <!-- Harvest every dependency from the bouncer build output (DLLs, runtimes\, .deps.json,
            runtimeconfig.json). The .exe is excluded because it is installed by the service
            components above; .pdb symbols are not shipped. -->
-      <Files Include="$(cs_windows_firewall_bouncer.TargetDir)\**"
-             Exclude="**\*.exe;**\*.pdb"
-             Directory="FirewallBouncerDir" />
+      <Files Directory="FirewallBouncerDir">
+        <Include Path="$(cs_windows_firewall_bouncer.TargetDir)\**" />
+        <Exclude Path="$(cs_windows_firewall_bouncer.TargetDir)\**\*.exe" />
+        <Exclude Path="$(cs_windows_firewall_bouncer.TargetDir)\**\*.pdb" />
+      </Files>
     </Feature>
 
     <Property Id="CSCLIPRESENT">

--- a/cs-windows-firewall-bouncer-tests/ConfigTests.cs
+++ b/cs-windows-firewall-bouncer-tests/ConfigTests.cs
@@ -31,6 +31,72 @@ fw_profiles:
         }
 
         [Fact]
+        public void ParsesPrometheusConfig()
+        {
+            const string yaml = @"
+api_endpoint: http://localhost:8080
+api_key: k
+log_media: file
+prometheus:
+  enabled: true
+  listen_addr: 0.0.0.0
+  listen_port: 60601
+";
+            var cfg = BouncerConfig.FromString(yaml).config;
+
+            Assert.NotNull(cfg.Prometheus);
+            Assert.True(cfg.Prometheus.Enabled);
+            Assert.Equal("0.0.0.0", cfg.Prometheus.ListenAddr);
+            Assert.Equal(60601, cfg.Prometheus.ListenPort);
+        }
+
+        [Fact]
+        public void PrometheusEnabledIsNullWhenOmitted()
+        {
+            // A null Enabled is treated as enabled by MetricsServer (on by default, opt-out).
+            const string yaml = @"
+api_endpoint: http://localhost:8080
+api_key: k
+log_media: file
+prometheus:
+  listen_port: 60601
+";
+            var cfg = BouncerConfig.FromString(yaml).config;
+
+            Assert.NotNull(cfg.Prometheus);
+            Assert.Null(cfg.Prometheus.Enabled);
+            Assert.Equal(60601, cfg.Prometheus.ListenPort);
+        }
+
+        [Fact]
+        public void ParsesDisabledPrometheusConfig()
+        {
+            const string yaml = @"
+api_endpoint: http://localhost:8080
+api_key: k
+log_media: file
+prometheus:
+  enabled: false
+";
+            var cfg = BouncerConfig.FromString(yaml).config;
+
+            Assert.NotNull(cfg.Prometheus);
+            Assert.False(cfg.Prometheus.Enabled);
+        }
+
+        [Fact]
+        public void ParsesConfigWithoutPrometheusBlock()
+        {
+            const string yaml = @"
+api_endpoint: http://localhost:8080
+api_key: k
+log_media: file
+";
+            var cfg = BouncerConfig.FromString(yaml).config;
+            Assert.Null(cfg.Prometheus);
+        }
+
+        [Fact]
         public void ParsesMinimalConfig()
         {
             const string yaml = @"

--- a/cs-windows-firewall-bouncer/Firewall.cs
+++ b/cs-windows-firewall-bouncer/Firewall.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Api;
+using Telemetry;
 
 namespace Fw
 {
@@ -191,7 +192,10 @@ namespace Fw
                     Logger.Trace("was not able to find a bucket for deleting {0}", decision.value);
                     continue;
                 }
-                bucket.RemoveIP(decision.value);
+                if (bucket.RemoveIP(decision.value))
+                {
+                    BouncerMetrics.Decisions.WithLabels("delete", decision.origin ?? "unknown").Inc();
+                }
             }
 
             foreach (var decision in decisions.New)
@@ -203,6 +207,7 @@ namespace Fw
                 }
                 var bucket = findAvailableBucket();
                 bucket.AddIP(decision.value);
+                BouncerMetrics.Decisions.WithLabels("add", decision.origin ?? "unknown").Inc();
             }
 
             List<FirewallRule> toDelete = new();
@@ -231,6 +236,9 @@ namespace Fw
             {
                 rulesBucket.Remove(fwRule);
             }
+
+            BouncerMetrics.FirewallRules.Set(rulesBucket.Count);
+            BouncerMetrics.ActiveDecisions.Set(rulesBucket.Sum(x => x.Length));
         }
 
         public void CreateRule(string name)

--- a/cs-windows-firewall-bouncer/Metrics.cs
+++ b/cs-windows-firewall-bouncer/Metrics.cs
@@ -1,0 +1,81 @@
+using System;
+using Prometheus;
+
+using Cfg;
+
+namespace Telemetry
+{
+    // Metric definitions. These are created at class-load and are no-ops until a
+    // MetricServer is started, so they are safe to reference unconditionally.
+    public static class BouncerMetrics
+    {
+        private const string Prefix = "cs_windows_fw_bouncer_";
+
+        public static readonly Gauge ActiveDecisions = Prometheus.Metrics.CreateGauge(
+            Prefix + "active_decisions",
+            "Number of IP addresses currently blocked by the bouncer.");
+
+        public static readonly Gauge FirewallRules = Prometheus.Metrics.CreateGauge(
+            Prefix + "firewall_rules",
+            "Number of Windows Firewall rules currently managed by the bouncer.");
+
+        public static readonly Counter Decisions = Prometheus.Metrics.CreateCounter(
+            Prefix + "decisions_total",
+            "Total number of decisions applied to the firewall.",
+            new CounterConfiguration { LabelNames = new[] { "action", "origin" } });
+
+        public static readonly Counter LapiRequests = Prometheus.Metrics.CreateCounter(
+            Prefix + "lapi_requests_total",
+            "Total number of requests made to the LAPI decisions stream.",
+            new CounterConfiguration { LabelNames = new[] { "status" } });
+    }
+
+    // Wraps the prometheus-net HttpListener-based metrics server.
+    public class MetricsServer
+    {
+        private readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+        private readonly bool enabled;
+        private readonly string addr;
+        private readonly int port;
+        private MetricServer server;
+
+        public MetricsServer(PrometheusConfig config)
+        {
+            // Metrics are on by default; only an explicit "enabled: false" disables them.
+            enabled = config?.Enabled ?? true;
+            addr = string.IsNullOrEmpty(config?.ListenAddr) ? "127.0.0.1" : config.ListenAddr;
+            port = config != null && config.ListenPort > 0 ? config.ListenPort : 60601;
+        }
+
+        public void Start()
+        {
+            if (!enabled)
+            {
+                Logger.Debug("Prometheus metrics are disabled");
+                return;
+            }
+            try
+            {
+                server = new MetricServer(hostname: addr, port: port);
+                server.Start();
+                Logger.Info("Prometheus metrics server listening on {0}:{1}/metrics", addr, port);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Could not start Prometheus metrics server: {0}", ex.Message);
+            }
+        }
+
+        public void Stop()
+        {
+            try
+            {
+                server?.Stop();
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug("Error while stopping Prometheus metrics server: {0}", ex.Message);
+            }
+        }
+    }
+}

--- a/cs-windows-firewall-bouncer/Program.cs
+++ b/cs-windows-firewall-bouncer/Program.cs
@@ -6,6 +6,7 @@ using CommandLine;
 using Fw;
 using Cfg;
 using Manager;
+using Telemetry;
 
 namespace cs_windows_firewall_bouncer
 {
@@ -168,8 +169,17 @@ namespace cs_windows_firewall_bouncer
             else
             {
                 Logger.Info("Running in interactive mode");
+                var metrics = new MetricsServer(config.config.Prometheus);
+                metrics.Start();
                 DecisionsManager mgr = new(config);
-                await mgr.Run();
+                try
+                {
+                    await mgr.Run();
+                }
+                finally
+                {
+                    metrics.Stop();
+                }
             }
         }
     }

--- a/cs-windows-firewall-bouncer/Service.cs
+++ b/cs-windows-firewall-bouncer/Service.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Cfg;
 using Fw;
 using Manager;
+using Telemetry;
 
 namespace cs_windows_firewall_bouncer
 {
@@ -22,6 +23,7 @@ namespace cs_windows_firewall_bouncer
 
         BouncerConfig config;
         DecisionsManager mgr;
+        MetricsServer metrics;
         CancellationTokenSource cts;
         Task runLoop;
         public Service(BouncerConfig config)
@@ -35,6 +37,8 @@ namespace cs_windows_firewall_bouncer
         protected override void OnStart(string[] args)
         {
             Logger.Debug("Onstart service");
+            metrics = new MetricsServer(config.config.Prometheus);
+            metrics.Start();
             mgr = new(config);
             cts = new CancellationTokenSource();
             runLoop = RunLoopAsync();
@@ -65,6 +69,7 @@ namespace cs_windows_firewall_bouncer
                 runLoop?.Wait(TimeSpan.FromSeconds(5));
             }
             catch (AggregateException) { }
+            metrics?.Stop();
             Firewall firewall = new(null);
             firewall.DeleteAllRules();
             cts?.Dispose();

--- a/cs-windows-firewall-bouncer/apiClient.cs
+++ b/cs-windows-firewall-bouncer/apiClient.cs
@@ -10,6 +10,8 @@ using System.Text.Json.Serialization;
 using System.Collections.Generic;
 using System.Linq;
 
+using Telemetry;
+
 namespace Api
 {
 
@@ -145,6 +147,7 @@ namespace Api
                 Logger.Trace("requesting {0}", uri);
                 response = await client.GetAsync(uri, ct);
                 response.EnsureSuccessStatusCode();
+                BouncerMetrics.LapiRequests.WithLabels("success").Inc();
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {
@@ -152,6 +155,7 @@ namespace Api
             }
             catch (Exception ex)
             {
+                BouncerMetrics.LapiRequests.WithLabels("error").Inc();
                 Logger.Error("Could not get decisions: {0}", ex.Message);
                 return null;
             }

--- a/cs-windows-firewall-bouncer/config.cs
+++ b/cs-windows-firewall-bouncer/config.cs
@@ -25,6 +25,16 @@ namespace Cfg
         public List<string> ScenariosNotContaining { get; set; }
         public List<string> Origins { get; set; }
         public string SupportedDecisionType { get; set; }
+
+        public PrometheusConfig Prometheus { get; set; }
+    }
+
+    public class PrometheusConfig
+    {
+        // Nullable so an absent value defaults to enabled, while "enabled: false" still opts out.
+        public bool? Enabled { get; set; }
+        public string ListenAddr { get; set; }
+        public int ListenPort { get; set; }
     }
 
     public class BouncerConfig

--- a/cs-windows-firewall-bouncer/config/cs-windows-firewall-bouncer.yaml
+++ b/cs-windows-firewall-bouncer/config/cs-windows-firewall-bouncer.yaml
@@ -3,3 +3,7 @@ api_key: ${API_KEY}
 update_frequency: 10
 log_media: file
 log_dir: C:\\ProgramData\\CrowdSec\\log\\
+prometheus:
+  enabled: true
+  listen_addr: 127.0.0.1
+  listen_port: 60601

--- a/cs-windows-firewall-bouncer/cs-windows-firewall-bouncer.csproj
+++ b/cs-windows-firewall-bouncer/cs-windows-firewall-bouncer.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="NLog" Version="6.1.3" />
+    <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.8" />
     <PackageReference Include="YamlDotNet" Version="18.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Add prometheus metrics:
 - Count of active decisions / firewall rules / LAPI calls
 - .NET runtime metrics exposed by default by the prometheus lib